### PR TITLE
Fixed C and C# Links Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
  - [JavaScript](#javascript)
  - [Java](#java)
- - [C#](#c-1)
+ - [C#](#c)
  - [CSS](#css)
- - [C](undefined)
+ - [C](#c-1)
  - [C++](#c-2)
  - [Clojure](#clojure)
  - [Go](#go)


### PR DESCRIPTION
Opened this PR to fix below issue :

Issue --> C and C# links in Contents section are not working

![links issue](https://user-images.githubusercontent.com/25107841/47330830-46bd0a80-d697-11e8-8735-ac72037b51e2.gif)
